### PR TITLE
update the program dates for ANRW'25

### DIFF
--- a/content/anrw/2025/attend.haml
+++ b/content/anrw/2025/attend.haml
@@ -10,7 +10,8 @@ other: false
   %p
     The ANRW 2025 will be a one-day workshop held at the Meliá Castilla Hotel
     &amp; Convention Center in Madrid, Spain, co-located with the IETF-123
-    meeting which runs from 19-25 July 2025 in the same venue.
+    meeting which runs from 19-25 July 2025 in the same venue. The workshop
+    will be held on Tuesday, July 22, 2025.
 
   %p
     All attendees

--- a/content/anrw/2025/index.haml
+++ b/content/anrw/2025/index.haml
@@ -3,7 +3,7 @@ title: Applied Networking Research Workshop (ANRW&nbsp;’25)
 menu: ANRW&nbsp;’25
 order: 1
 location: Madrid, Spain
-date: Week of July 19-25, 2024
+date: Week of July 22, 2025
 ietf: IETF-123
 ---
 

--- a/layouts/anrw/2025/dates_.haml
+++ b/layouts/anrw/2025/dates_.haml
@@ -27,5 +27,5 @@
           ANRW&nbsp;’25 workshop
       %td{ colspan: 2 }
         %b
-          Week of July 19-25, 2025
+          Tuesday, July 22, 2025
 

--- a/layouts/anrw/2025/place_.haml
+++ b/layouts/anrw/2025/place_.haml
@@ -1,4 +1,4 @@
 %p
   The ANRW ’25 is a one-day workshop that will take place in Madrid, Spain,
-  co-locating with the IETF-123 meeting, in the week of July 19-25, 2025.
+  co-locating with the IETF-123 meeting. The workshop will be held on Tuesday, July 22, 2025.
 


### PR DESCRIPTION
The current website only lists the IETF-123 dates and not the specific date for the ANRW'25 program.