### PR TITLE
add links to ACM DL for ANRW'25

### DIFF
--- a/content/anrw/2025/program.haml
+++ b/content/anrw/2025/program.haml
@@ -606,9 +606,9 @@ menu: Program
 
 
 
-  %h2 Proceedings
--#%p
-  %a{ :href => "https://dl.acm.org/doi/proceedings/10.1145/3673422", 
+%h2 Proceedings
+%p
+  %a{ :href => "https://dl.acm.org/doi/proceedings/10.1145/3744200", 
       :referrerpolicy => "no-referrer-when-downgrade"  }
     Proceedings of the Applied Networking Research Workshop 2025
   are available from the ACM Digital Library.

--- a/content/anrw/2025/program.haml
+++ b/content/anrw/2025/program.haml
@@ -60,11 +60,9 @@ menu: Program
         %p
           %a{ name: "p01"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674887",
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744774",
                 :referrerpolicy => "no-referrer-when-downgrade"} 
-              HTTP/3's Extensible Prioritization Scheme in the Wild
-
-            Carbon-Intelligent Content Scheduling in CDNs
+              Carbon-Intelligent Content Scheduling in CDNs
             
           %br
           S. El-Zahr,
@@ -80,11 +78,9 @@ menu: Program
         %p
           %a{ name: "p02"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            End-to-End 360º Video Streaming over HTTP/3: Architecture and Implementation
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744784",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              End-to-End 360º Video Streaming over HTTP/3: Architecture and Implementation
           %br
           F. Rosa,
           S. Ferlin,
@@ -106,11 +102,9 @@ menu: Program
         %p
           %a{ name: "p03"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674887",
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744757",
                 :referrerpolicy => "no-referrer-when-downgrade"} 
-              HTTP/3's Extensible Prioritization Scheme in the Wild
-
-            Two Decades of IETF Affiliations: Evolution and Impact
+              Two Decades of IETF Affiliations: Evolution and Impact
             
           %br
           Y. Zhang,
@@ -130,11 +124,9 @@ menu: Program
         %p
           %a{ name: "p04"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Empowering IETF Collaboration with NLP Search Innovations and LLM-Enhanced RFC Writing
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744761",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Empowering IETF Collaboration with NLP Search Innovations and LLM-Enhanced RFC Writing
           %br
           J. Bian
           and
@@ -148,11 +140,9 @@ menu: Program
         %p
           %a{ name: "p05"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Large Language Model Driven Automated Network Protocol Testing
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744763",
+                :referrerpolicy => "no-referrer-when-downgrade"}
+              Large Language Model Driven Automated Network Protocol Testing
           %br
           Y. Wei,
           K. Chi,
@@ -179,11 +169,9 @@ menu: Program
         %p
           %a{ name: "p06"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674887",
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744758",
                 :referrerpolicy => "no-referrer-when-downgrade"} 
-              HTTP/3's Extensible Prioritization Scheme in the Wild
-
-            PhantomLink: Emulating Virtual End-to-End Links on Ground and in Orbit
+              PhantomLink: Emulating Virtual End-to-End Links on Ground and in Orbit
             
           %br
           R. Ohs,
@@ -201,11 +189,9 @@ menu: Program
         %p
           %a{ name: "p07"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            BrowsEm: Model-based Web Site Loading Emulation
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744759",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              BrowsEm: Model-based Web Site Loading Emulation
           %br
           K. Holzinger,
           F. Klein,
@@ -223,11 +209,9 @@ menu: Program
         %p
           %a{ name: "p08"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Using Explicit (Host-to-Network) Flow Measurements for Network Tomography
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744769",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Using Explicit (Host-to-Network) Flow Measurements for Network Tomography
           %br
           I. Kunze,
           C. Sander,
@@ -250,11 +234,9 @@ menu: Program
         %p
           %a{ name: "p09"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674887",
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744766",
                 :referrerpolicy => "no-referrer-when-downgrade"} 
-              HTTP/3's Extensible Prioritization Scheme in the Wild
-
-            Getting up to Speed with Neqo and Careful Resume
+              Getting up to Speed with Neqo and Careful Resume
             
           %br
           N. Fischer,
@@ -271,11 +253,9 @@ menu: Program
         %p
           %a{ name: "p10"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            TCP Congestion Control Performance over Starlink
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744760",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              TCP Congestion Control Performance over Starlink
           %br
           J. Garcia,
           S. Sundberg,
@@ -290,11 +270,9 @@ menu: Program
         %p
           %a{ name: "p11"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Understanding QUIC's Throughput Speedbumps
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744780",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Understanding QUIC's Throughput Speedbumps
           %br
           S. Mukherjee,
           D. Lei,
@@ -310,11 +288,9 @@ menu: Program
         %p
           %a{ name: "p12"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Cascades of Nested Acknowledgments in Multi-Hop MASQUE
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744773",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Cascades of Nested Acknowledgments in Multi-Hop MASQUE
           %br
           K. Elmenhorst,
           M. Kühlewind,
@@ -331,11 +307,9 @@ menu: Program
         %p
           %a{ name: "p13"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Reproducing and Solving a Fallback Issue in TCP Prague
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744770",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Reproducing and Solving a Fallback Issue in TCP Prague
           %br
           L. Hagen
           and
@@ -356,11 +330,9 @@ menu: Program
         %p
           %a{ name: "p14"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674887",
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744768",
                 :referrerpolicy => "no-referrer-when-downgrade"} 
-              HTTP/3's Extensible Prioritization Scheme in the Wild
-
-            Towards Comprehensive Mapping of Africa’s Internet Infrastructure
+              Towards Comprehensive Mapping of Africa’s Internet Infrastructure
             
           %br
           N. Anya
@@ -375,11 +347,9 @@ menu: Program
         %p
           %a{ name: "p15"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Towards Operational and Security Best Practices for DNS in the Internet of Things
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744764",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Towards Operational and Security Best Practices for DNS in the Internet of Things
           %br
           A. Losty,
           A. Mishra,
@@ -395,11 +365,9 @@ menu: Program
         %p
           %a{ name: "p16"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Towards switched-homing for Internet access
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744771",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Towards switched-homing for Internet access
           %br
           P. Van Ouytsel,
           M. Baerts,
@@ -414,11 +382,9 @@ menu: Program
         %p
           %a{ name: "p17"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Identifying Roadblocks in Building Decentralized Apps
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744778",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Identifying Roadblocks in Building Decentralized Apps
           %br
           T. Yu,
           A. Thieme,
@@ -433,11 +399,9 @@ menu: Program
         %p
           %a{ name: "p18"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Straggler-Aware Observability for Flow Scheduling
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744782",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Straggler-Aware Observability for Flow Scheduling
           %br
           M. Maulana,
           H. Mostafaei,
@@ -452,11 +416,9 @@ menu: Program
         %p
           %a{ name: "p19"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Towards Understanding Middlebox Deployments in Dutch ASes: Impact of IP Sampling Size
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744765",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Towards Understanding Middlebox Deployments in Dutch ASes: Impact of IP Sampling Size
           %br
           B. Ulukapi,
           A. Sperotto,
@@ -471,11 +433,9 @@ menu: Program
         %p
           %a{ name: "p20"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Non-Standard Large TTLs in DNS Query Responses
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744777",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Non-Standard Large TTLs in DNS Query Responses
           %br
           Y. Shavitt
           and
@@ -496,11 +456,9 @@ menu: Program
         %p
           %a{ name: "p21"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Locating and Enumerating anycast: a Comparison of Two Approaches
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744783",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Locating and Enumerating anycast: a Comparison of Two Approaches
           %br
           R. Hendriks,
           T. Betzer,
@@ -518,11 +476,9 @@ menu: Program
         %p
           %a{ name: "p22"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Stack Management for MPLS Network Actions: Integration of Nodes with Limited Hardware Capabilities
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744779",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Stack Management for MPLS Network Actions: Integration of Nodes with Limited Hardware Capabilities
           %br
           F. Ihle
           and
@@ -536,11 +492,9 @@ menu: Program
         %p
           %a{ name: "p23"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            On the Benefits of Predictable Traffic in Virtual Switches: A Case Study
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744762",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              On the Benefits of Predictable Traffic in Virtual Switches: A Case Study
           %br
           E. Ståhl,
           S. Ferlin,
@@ -557,11 +511,9 @@ menu: Program
         %p
           %a{ name: "p24"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Analyzing Internet background radiation with reflective network telescopes
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744776",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Analyzing Internet background radiation with reflective network telescopes
           %br
           E. Chan,
           R. Mok,
@@ -584,11 +536,9 @@ menu: Program
         %p
           %a{ name: "p21"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            Secure Deployment of eBPF Programs Made Manifest
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744781",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              Secure Deployment of eBPF Programs Made Manifest
           %br
           B. Gbadamosi,
           T. Pulls,
@@ -603,11 +553,9 @@ menu: Program
         %p
           %a{ name: "p22"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            MAY is not enough! QUIC servers SHOULD skip packet numbers
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744772",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              MAY is not enough! QUIC servers SHOULD skip packet numbers
           %br
           L. Navarre
           and
@@ -621,11 +569,9 @@ menu: Program
         %p
           %a{ name: "p23"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            PQC for DNSSEC: a format size analysis on Falcon signatures
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744767",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              PQC for DNSSEC: a format size analysis on Falcon signatures
           %br
           G. Fabrizio,
           R. Koning,
@@ -644,11 +590,9 @@ menu: Program
         %p
           %a{ name: "p24"}
           %b
-            -#%a{ :href => "https://dl.acm.org/doi/10.1145/3673422.3674894",
-                :referrerpolicy => "no-referrer-when-downgrade"} 
-              The Observer Effect in Computer Networks
-              
-            A Framework for Secure Autonomic IoT Device Management in Constrained Networks
+            %a{ :href => "https://dl.acm.org/doi/10.1145/3744200.3744775",
+                :referrerpolicy => "no-referrer-when-downgrade"}               
+              A Framework for Secure Autonomic IoT Device Management in Constrained Networks
           %br
           M. Hatami,
           S. Céspedes,


### PR DESCRIPTION
Added the ACM digital library URLs to the ANRW 2025 program page.
The PDFs will be available on the first day of the workshop.